### PR TITLE
Update nodemon version

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,6 +19,6 @@
   },
   "homepage": "https://github.com/bk1012/nodemon-docker#readme",
   "dependencies": {
-    "nodemon": "^2.0.22"
+    "nodemon": "^2.0.23"
   }
 }


### PR DESCRIPTION
Related to #1

Update the `nodemon` version in `package.json` to `^2.0.23`.

* Modify the `dependencies` section in `package.json` to specify `nodemon` version `^2.0.23` instead of `^2.0.22`.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/bk1012/nodemon-docker/issues/1?shareId=e470ed78-fe13-4007-8fe9-6d3b75716d71).